### PR TITLE
add 7.6.1810 (#135)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,10 @@
+FROM scratch
+ADD centos-7arm64-docker.tar.xz /
+
+LABEL org.label-schema.schema-version="1.0" \
+    org.label-schema.name="CentOS Base Image" \
+    org.label-schema.vendor="CentOS" \
+    org.label-schema.license="GPLv2" \
+    org.label-schema.build-date="20181220"
+
+CMD ["/bin/bash"]

--- a/docker/cccp.yaml
+++ b/docker/cccp.yaml
@@ -1,0 +1,2 @@
+job-id: centos-base
+test-skip: true


### PR DESCRIPTION
The centos-7arm64-docker.tar.xz was built using KS file: 
https://github.com/CentOS/sig-cloud-instance-build/blob/master/docker/centos-7-aarch64.ks
by invoking shell script: 
https://github.com/CentOS/sig-cloud-instance-build/blob/master/docker/containerbuild.sh
